### PR TITLE
Fix missing linebreaks in data extraction lookup values field

### DIFF
--- a/parsifal/apps/reviews/planning/templates/planning/partial_data_extraction_field_form.html
+++ b/parsifal/apps/reviews/planning/templates/planning/partial_data_extraction_field_form.html
@@ -12,7 +12,7 @@
   </td>
   <td style="vertical-align: middle;">
     <div class="select-field" style="{% if not field.is_select_field %}display: none{% endif %}">
-      <textarea class="form-control" id="data-extraction-lookup-values" style="width: 250px">{% for value in field.get_select_values %}{{ value }}{% endfor %}</textarea>
+      <textarea class="form-control" id="data-extraction-lookup-values" style="width: 250px">{% for value in field.get_select_values %}{{ value }}&#10;{% endfor %}</textarea>
       <p>Add one value per line.</p>
     </div>
     <div class="no-select-field" style="{% if field.is_select_field %}display: none{% endif %}">


### PR DESCRIPTION
This fixes an issue with the data extraction form where linebreaks are lost when editing a select one or select many field