### PR TITLE
Fix local dependencies and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,25 @@ The project is currently running on the following versions:
 
 To run the project locally first you need to clone the repository:
 
-```
+```bash
 git clone https://github.com/vitorfs/parsifal.git
 ```
 
 Create a virtualenv:
 
+```bash
+python3 -m venv venv
 ```
-virtualenv venv -p python3
+
+Active virtualenv:
+
+```bash
+source venv/bin/activate
 ```
 
 Install the development requirements:
 
-```
+```bash
 pip install -r requirements/local.txt
 ```
 
@@ -62,38 +68,44 @@ Now you should either setup a local PostgreSQL database or use SQLite.
 
 Create a `.env` file in the project root (you can create one by making a copy of the `.env.example`):
 
-```
+```bash
 cp .env.example .env
 ```
 
 Now add the `DATABASE_URL` with the connection string pointing to your local database:
 
-```
+```bash
 DATABASE_URL=postgres://richardwagner:holygrail@localhost:5432/parsifal
 ```
 
 Or for SQLite:
 
-```
+```bash
 DATABASE_URL=sqlite:////tmp/parsifal.sqlite3
 ```
 
 Or if you want to place it elsewhere:
 
-```
+```bash
 DATABASE_URL=sqlite:////Users/vitor/dev/parsifal/parsifal.sqlite3
 ```
 
 Now run the migrations:
 
-```
+```bbash
 python manage.py migrate
 ```
 
 Run the local server:
 
-```
+```bash
 python manage.py runserver
+```
+
+Create super user:
+
+```bash
+python manage.py createsuperuser
 ```
 
 ## License

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'parsifal.settings.local')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "parsifal.settings.local")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 119
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r tests.txt
 
 django-debug-toolbar==3.5.0
-git+git://github.com/jazzband/django-silk.git#egg=django-silk
+django-silk==4.4.1
 ipython==8.4.0
 towncrier==21.9.0


### PR DESCRIPTION
## Changes

- Fix django-silk version: use PyPi package with specific version
- Update readme
  - Add syntax language to code blocks
  - Add create superuser documentation
  - Use venv python module instead of virtualenv
- Add python 3.9 to black target version
- Run black over manage.py

## Issues

- Fix #135